### PR TITLE
Implemented issue #31

### DIFF
--- a/comment_scan.rb
+++ b/comment_scan.rb
@@ -65,7 +65,8 @@ cb.gen_hooks do
         comment = mc_comment
         if !comment.nil?
           comment = Comment.find_by(comment_id: comment.id) if comment.is_a? SE::API::Comment
-          case msg.body.split(' ')[1].downcase
+          reply_args = msg.body.split(' ')
+          case reply_args[1].downcase
           when 'tp'
             comment.tps ||= 0
             comment.tps += 1
@@ -119,7 +120,12 @@ cb.gen_hooks do
               scan_comments(c, cli:cli, settings:settings, cb:cb)
             end
           else
-            cb.say "Invalid feedback type. Valid feedback types are tp, fp, rude, and wrongo", room_id
+            if reply_args.length > 2 #They're not trying to give a command
+              #Maybe make conversation back (20% chance)
+              cb.say random_response(), room_id if rand() > 0.8
+            else
+              cb.say "Invalid feedback type. Valid feedback types are tp, fp, rude, and wrongo", room_id
+            end
           end
           comment.save
         elsif !hg_comment.nil?

--- a/comment_scan.rb
+++ b/comment_scan.rb
@@ -122,7 +122,7 @@ cb.gen_hooks do
           else
             if reply_args.length > 2 #They're not trying to give a command
               #Maybe make conversation back (20% chance)
-              cb.say random_response(), room_id if rand() > 0.8
+              cb.say ":#{msg.id} #{random_response()}", room_id if rand() > 0.8
             else
               cb.say "Invalid feedback type. Valid feedback types are tp, fp, rude, and wrongo", room_id
             end

--- a/comment_scan/helpers.rb
+++ b/comment_scan/helpers.rb
@@ -142,3 +142,15 @@ end
 def timestamp_to_date(timestamp)
   Time.at(timestamp.to_i).to_date
 end
+
+def random_response()
+  responses = ["Ain't that the truth.",
+               "You're telling me.",
+               "Yep. That's about the size of it.",
+               "That's what I've been saying for $(AGE_OF_BOT)!",
+               "What else is new?",
+               "For real?",
+               "Humans, amirite?"]
+
+  return responses[rand(responses.length())]
+end


### PR DESCRIPTION
Updated behavior when we receive invalid feedback to a comment report response. If the response is >1 word (the max length for a response command to a comment report) we'll now do nothing 80% of the time (as opposed to posting "Invalid feedback type..."). 20% of the time we'll ping the user response and give a fun response of our own.