### PR TITLE
Inclusion of thwait and e2mmap libraries on >2.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,10 @@ gem "activerecord"
 gem "sqlite3"
 gem "rake"
 #gem "rugged"#, git: "https://github.com/libgit2/rugged"
+if RUBY_VERSION >= '2.7'
+  gem 'e2mmap'
+  gem 'thwait'
+end
 
 gem "pry-byebug"
 gem 'httparty'


### PR DESCRIPTION
Ruby 2.7.0 removed two mandatory gems: thwait and e2mmap, more info [here](https://github.com/moove-it/sidekiq-scheduler/issues/298), added check if >2.7.0 to include such libraries.